### PR TITLE
fix: update icon packager to provide valid attributes

### DIFF
--- a/packages/style-forge/src/plugins/packager/icons-module/data-manipulation.ts
+++ b/packages/style-forge/src/plugins/packager/icons-module/data-manipulation.ts
@@ -1,5 +1,5 @@
 import { DOMParser } from 'xmldom';
-import { indentedLine, getDistinctFills } from '../../../utils';
+import { indentedLine, getDistinctFills, getCamelCase } from '../../../utils';
 import { FileDescription, IconDefinition, IconObject } from '../../../types';
 
 export const createIconsModule = (data: IconObject) => {
@@ -95,7 +95,7 @@ const generateChildren = (
           const attrValue = childAttr.value;
           if (!(attrName === 'fill' && ignoreFills)) {
             content += indentedLine(
-              `'${attrName}': '${attrValue}',`,
+              `'${getCamelCase(attrName)}': '${attrValue}',`,
               indent + 1,
             );
           }

--- a/packages/style-forge/src/plugins/packager/icons-module/index.test.ts
+++ b/packages/style-forge/src/plugins/packager/icons-module/index.test.ts
@@ -78,7 +78,7 @@ const expectedResult = [
       os.EOL +
       "    /* #__PURE__ */ React.createElement('g', {" +
       os.EOL +
-      "      'clip-path': 'url(#clip0_8102_4924)'," +
+      "      'clipPath': 'url(#clip0_8102_4924)'," +
       os.EOL +
       '    },' +
       os.EOL +

--- a/packages/style-forge/src/utils/distinct-fills/index.ts
+++ b/packages/style-forge/src/utils/distinct-fills/index.ts
@@ -19,7 +19,6 @@ export const getDistinctFills = (
     }
     const childAttrs = (child as Element).attributes;
     if (childAttrs && childAttrs.getNamedItem('fill')) {
-      console.log(childAttrs.getNamedItem('fill')?.value);
       fills.push(String(childAttrs.getNamedItem('fill')?.value));
     }
   }

--- a/packages/web-interface/components/layout/index.tsx
+++ b/packages/web-interface/components/layout/index.tsx
@@ -99,7 +99,7 @@ export const Layout = ({
   return (
     <>
       <Head>
-        <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+        <meta httpEquiv='Content-Type' content='text/html; charset=utf-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1' />
         <title>{metaTitle}</title>
         <meta name='title' content={metaTitle} />

--- a/packages/web-interface/package.json
+++ b/packages/web-interface/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf ./.next & rimraf ./out"
   },
   "dependencies": {
-    "@monsterww/style-forge": "^0.0.7",
+    "@monsterww/style-forge": "^0.0.8",
     "axios": "^0.21.1",
     "archiver": "^5.3.1",
     "bootstrap": "^5.2.3",


### PR DESCRIPTION
# Description

Fix for Icon packaging. Updates packager logic to provide valid attributes, i.e. instead of `fill-rule` the output will contain `fillRule`.